### PR TITLE
[KAN-502] Collect Textract results and assemble Key Value Pairs

### DIFF
--- a/deploy/production-fn.json
+++ b/deploy/production-fn.json
@@ -17,8 +17,7 @@
       "DATA_S3_BUCKET_NAME": "le-prod-stp-email-data",
       "RESULTS_S3_BUCKET_NAME": "le-prod-stp-textract-results",
       "NODE_ENV": "production",
-      "APP_NAME": "prod-fn-stp-textract-results",
-      "WHITELIST_ORIGINATORS": ""
+      "APP_NAME": "prod-fn-stp-textract-results"
     }
   },
   "KMSKeyArn": "",

--- a/deploy/production-fn.json
+++ b/deploy/production-fn.json
@@ -15,6 +15,7 @@
   "Environment": {
     "Variables": {
       "DATA_S3_BUCKET_NAME": "le-prod-stp-email-data",
+      "RESULTS_S3_BUCKET_NAME": "le-prod-stp-textract-results",
       "NODE_ENV": "production",
       "APP_NAME": "prod-fn-stp-textract-results",
       "WHITELIST_ORIGINATORS": ""

--- a/deploy/test-fn.json
+++ b/deploy/test-fn.json
@@ -15,11 +15,10 @@
   "Environment": {
     "Variables": {
       "DATA_S3_BUCKET_NAME": "le-test-stp-email-data",
+      "RESULTS_S3_BUCKET_NAME": "le-test-stp-textract-results",
       "NODE_ENV": "production",
       "APP_NAME": "test-fn-stp-textract-results",
-      "WHITELIST_ORIGINATORS": "luxuryescapes.com",
-      "SNS_CHANNEL": "arn:aws:sns:ap-southeast-2:801230920622:test-le-textract",
-      "SNS_ROLE_ARN": "arn:aws:iam::801230920622:role/le-textract-service-role"
+      "WHITELIST_ORIGINATORS": "luxuryescapes.com"
     }
   },
   "KMSKeyArn": "",

--- a/deploy/test-fn.json
+++ b/deploy/test-fn.json
@@ -17,8 +17,7 @@
       "DATA_S3_BUCKET_NAME": "le-test-stp-email-data",
       "RESULTS_S3_BUCKET_NAME": "le-test-stp-textract-results",
       "NODE_ENV": "production",
-      "APP_NAME": "test-fn-stp-textract-results",
-      "WHITELIST_ORIGINATORS": "luxuryescapes.com"
+      "APP_NAME": "test-fn-stp-textract-results"
     }
   },
   "KMSKeyArn": "",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export const APP_NAME = process.env.APP_NAME || "test-fn-stp-textract-results";
 
 export const DEBUG = process.env.DEBUG === "true";
 
+export const DATA_S3_BUCKET_NAME = process.env.DATA_S3_BUCKET_NAME || "";
 export const RESULTS_S3_BUCKET_NAME = process.env.RESULTS_S3_BUCKET_NAME || "";
 
 export const SNS_CHANNEL = process.env.SNS_CHANNEL || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,155 @@
 import { S3, Textract } from "aws-sdk";
+import { DATA_S3_BUCKET_NAME } from "./config";
 import { RESULTS_S3_BUCKET_NAME } from "./config";
 
-// const s3 = new S3();
+const s3 = new S3();
 const textract = new Textract();
 import { SNSEvent } from "aws-lambda";
 
+interface KeyValuePairs {
+  [key: string]: string;
+}
+
+interface BlockMap {
+  [key: string]: Textract.Block;
+}
+
 export const handler = async (event: SNSEvent): Promise<string> => {
-  console.log(JSON.stringify(event, null, 2));
-  console.log(RESULTS_S3_BUCKET_NAME);
+  // console.log(JSON.stringify(event, null, 2));
 
   const { Sns } = event.Records[0];
   const message = JSON.parse(Sns.Message);
-  console.log(JSON.stringify(message, null, 2));
+  const { S3ObjectName } = message.DocumentLocation;
+  const d = new Date(message.Timestamp);
+  const s3prefix = `${message.JobTag || "unknown"}/${d
+    .toISOString()
+    .replace(/-/g, "/")
+    .replace(/:/g, "-")}`;
+  const fileName = S3ObjectName.split("/").slice(-1)[0];
+  const metaDataS3ObjectName = S3ObjectName.replace(fileName, "_meta.json");
+  let error = null;
+
+  //console.log(JSON.stringify(message, null, 2));
+
   if (message.Status === "SUCCEEDED") {
     // Get textract results and store in S3
-    const textractResults = await textract
-      .getDocumentAnalysis({
-        JobId: message.JobId
-      })
-      .promise();
-    console.log(JSON.stringify(textractResults, null, 2));
+    try {
+      const textractResults = await textract
+        .getDocumentAnalysis({
+          JobId: message.JobId
+        })
+        .promise();
+
+      const blocks: Textract.BlockList = textractResults.Blocks || [];
+
+      console.log("Collecting Key Value Pairs...");
+
+      const keyMap: BlockMap = {};
+      const valueMap: BlockMap = {};
+      const blockMap: BlockMap = {};
+
+      for (const block of blocks) {
+        const blockId: string = block.Id || "";
+        blockMap[blockId] = block;
+        if (block.BlockType == "KEY_VALUE_SET") {
+          const entityTypes = block.EntityTypes || [];
+          if (entityTypes.some(et => et == "KEY")) {
+            keyMap[blockId] = block;
+          } else {
+            valueMap[blockId] = block;
+          }
+        }
+      }
+
+      const findValueBlock = (
+        keyBlock: Textract.Block
+      ): Textract.Block | undefined => {
+        for (const relationShip of keyBlock.Relationships || []) {
+          if (relationShip.Type === "VALUE" && relationShip.Ids?.length) {
+            return valueMap[relationShip.Ids[0]];
+          }
+        }
+      };
+
+      const getText = (block: Textract.Block, blockMap: BlockMap): string => {
+        let text = "";
+        for (const relationShip of block.Relationships || []) {
+          if (relationShip.Type === "CHILD" && relationShip.Ids?.length) {
+            for (const childId of relationShip.Ids) {
+              const word = blockMap[childId];
+              if (word.BlockType === "WORD") {
+                text = text + word.Text + " ";
+              } else if (
+                word.BlockType == "SELECTION_ELEMENT" &&
+                word.SelectionStatus === "SELECTED"
+              ) {
+                text = text + "X ";
+              }
+            }
+          }
+        }
+        return text.trimEnd();
+      };
+
+      const kvp: KeyValuePairs = {};
+
+      for (const k in keyMap) {
+        const keyBlock = keyMap[k];
+        const valueBlock = findValueBlock(keyBlock);
+        if (valueBlock) {
+          let key: string = getText(keyBlock, blockMap);
+          const value: string = getText(valueBlock, blockMap);
+          let duplicateNumber = 1;
+          while (kvp[key]) {
+            key = key + duplicateNumber;
+            duplicateNumber++;
+          }
+          kvp[key] = value;
+        }
+      }
+
+      console.log("Writing key value pairs...");
+      await s3
+        .putObject({
+          Bucket: RESULTS_S3_BUCKET_NAME,
+          Key: `extracted/${s3prefix}/${fileName}.kvp.json`,
+          Body: JSON.stringify(kvp, null, 2)
+        })
+        .promise();
+
+      console.log("Writing block results...");
+      await s3
+        .putObject({
+          Bucket: RESULTS_S3_BUCKET_NAME,
+          Key: `extracted/${s3prefix}/${fileName}.blocks.json`,
+          Body: JSON.stringify(textractResults, null, 2)
+        })
+        .promise();
+
+      console.log("Copying original file...");
+      await s3
+        .copyObject({
+          CopySource: `${DATA_S3_BUCKET_NAME}/${S3ObjectName}`,
+          Bucket: RESULTS_S3_BUCKET_NAME,
+          Key: `extracted/${s3prefix}/${fileName}`
+        })
+        .promise();
+
+      console.log("Copying metadata...");
+      await s3
+        .copyObject({
+          CopySource: `${DATA_S3_BUCKET_NAME}/${metaDataS3ObjectName}`,
+          Bucket: RESULTS_S3_BUCKET_NAME,
+          Key: `extracted/${s3prefix}/meta.json`
+        })
+        .promise();
+    } catch (err) {
+      error = { type: "Output error", message: { err } };
+    }
   } else {
-    // Create error results and store in S3 (log?)
+    error = { type: "Textract failed", message: { message } };
   }
-  return "Finished processing.";
+  return error?.message
+    ? JSON.stringify(error, null, 2)
+    : "Finished processing.";
 };


### PR DESCRIPTION
Updated lambda code to fetch analysis results from Textract.

(Analysis jobs are sent by another lambda see: https://github.com/brandsExclusive/fn-stp-textract)

Stitched together the KVP blocks (which are very convoluted!)

Saves to S3 bucket